### PR TITLE
Use SQL query to search updated schema for questions

### DIFF
--- a/classes/improviser.php
+++ b/classes/improviser.php
@@ -88,10 +88,13 @@ class improviser {
         if (!$category) {
             return false;
         }
-        $questions = $DB->get_records('question', [
-            'category' => $category->id,
-            'name' => '{IMPROV}' . $name
-        ]);
+        $sql = "SELECT qbe.id
+                  FROM {question_bank_entries} qbe
+                  JOIN {question} q
+                    ON q.id = qbe.id
+                 WHERE qbe.questioncategoryid = :catid
+                   AND q.name LIKE :name";
+        $questions = $DB->get_records_sql($sql, ['catid' => $category->id, 'name' => '{IMPROV}' . $name]);
         if (!$questions) {
             return false;
         }


### PR DESCRIPTION
The database schema has changed in Moodle 4.0, meaning that the current call to get_records fails because the "question" table no longer contains information about the categories. This information has instead been split off into the "question_bank_entries" table. To get the same information as before, we need to select from this table.

Fixes #77