### PR TITLE
Fix errors on edit tab in Moodle 4.0

### DIFF
--- a/classes/bank/jazzquiz_question_bank_view.php
+++ b/classes/bank/jazzquiz_question_bank_view.php
@@ -75,16 +75,21 @@ class jazzquiz_question_bank_view extends \core_question\local\bank\view {
     /**
      * Shows the question bank editing interface.
      * @param string $tabname
-     * @param int $page
-     * @param int $perpage
-     * @param string $cat
-     * @param bool $recurse
-     * @param bool $showhidden
-     * @param bool $showquestiontext
-     * @param array $tagids
+     * @param array $pagevars
      * @throws \coding_exception
      */
-    public function display($tabname, $page, $perpage, $cat, $recurse, $showhidden, $showquestiontext, $tagids = []) {
+    public function display($pagevars, $tabname): void {
+        $page = $pagevars['qpage'];
+        $perpage = $pagevars['qperpage'];
+        $cat = $pagevars['cat'];
+        $recurse = $pagevars['recurse'];
+        $showhidden = $pagevars['showhidden'];
+        $showquestiontext = $pagevars['qbshowtext'];
+        $tagids = [];
+        if (!empty($pagevars['qtagids'])) {
+            $tagids = $pagevars['qtagids'];
+        }
+
         global $PAGE;
 
         if ($this->process_actions_needing_ui()) {

--- a/classes/bank/jazzquiz_question_bank_view.php
+++ b/classes/bank/jazzquiz_question_bank_view.php
@@ -82,9 +82,6 @@ class jazzquiz_question_bank_view extends \core_question\local\bank\view {
 
         global $PAGE;
 
-        if ($this->process_actions_needing_ui()) {
-            return;
-        }
         $contexts = $this->contexts->having_one_edit_tab_cap($tabname);
         list($categoryid, $contextid) = explode(',', $cat);
         $catcontext = \context::instance_by_id($contextid);

--- a/classes/bank/jazzquiz_question_bank_view.php
+++ b/classes/bank/jazzquiz_question_bank_view.php
@@ -51,10 +51,10 @@ class jazzquiz_question_bank_view extends \core_question\local\bank\view {
         // Full class names for question bank columns.
         $columns = [
             '\\mod_jazzquiz\\bank\\question_bank_add_to_jazzquiz_action_column',
-            'core_question\\bank\\checkbox_column',
-            'core_question\\bank\\question_type_column',
-            'core_question\\bank\\question_name_column',
-            'core_question\\bank\\preview_action_column'
+            'core_question\\local\\bank\\checkbox_column',
+            'qbank_viewquestiontype\\question_type_column',
+            'qbank_viewquestionname\\viewquestionname_column_helper',
+            'qbank_previewquestion\\preview_action_column'
         ];
         foreach ($columns as $column) {
             $this->requiredcolumns[$column] = new $column($this);

--- a/classes/bank/jazzquiz_question_bank_view.php
+++ b/classes/bank/jazzquiz_question_bank_view.php
@@ -96,15 +96,11 @@ class jazzquiz_question_bank_view extends \core_question\local\bank\view {
 
         // Continues with list of questions.
         $this->display_question_list(
-            $this->contexts->having_one_edit_tab_cap($tabname),
             $this->baseurl,
             $cat,
-            $this->cm,
             null,
             $page,
-            $perpage,
-            $showhidden,
-            $showquestiontext,
+            $perpage,   
             $this->contexts->having_cap('moodle/question:add')
         );
         $this->display_add_selected_questions_button();

--- a/classes/bank/jazzquiz_question_bank_view.php
+++ b/classes/bank/jazzquiz_question_bank_view.php
@@ -63,16 +63,6 @@ class jazzquiz_question_bank_view extends \core_question\local\bank\view {
     }
 
     /**
-     * Display the header element for the question bank.
-     * This is a copy of the super class method in 3.5+, and only exists for compatibility with 3.4 and earlier.
-     * TODO: This override should be removed in the future.
-     */
-    protected function display_question_bank_header() {
-        global $OUTPUT;
-        echo $OUTPUT->heading(get_string('questionbank', 'question'), 2);
-    }
-
-    /**
      * Shows the question bank editing interface.
      * @param string $tabname
      * @param array $pagevars

--- a/classes/bank/jazzquiz_question_bank_view.php
+++ b/classes/bank/jazzquiz_question_bank_view.php
@@ -47,7 +47,7 @@ class jazzquiz_question_bank_view extends \core_question\local\bank\view {
      * Define the columns we want to be displayed on the question bank
      * @return array
      */
-    protected function wanted_columns() {
+    protected function wanted_columns(): array {
         // Full class names for question bank columns.
         $columns = [
             '\\mod_jazzquiz\\bank\\question_bank_add_to_jazzquiz_action_column',

--- a/classes/bank/jazzquiz_question_bank_view.php
+++ b/classes/bank/jazzquiz_question_bank_view.php
@@ -141,7 +141,7 @@ class jazzquiz_question_bank_view extends \core_question\local\bank\view {
      * @throws \coding_exception
      * @throws \moodle_exception
      */
-    protected function create_new_question_form($category, $add) {
+    protected function create_new_question_form($category, $add): void {
         echo '<div class="createnewquestion">';
         if ($add) {
             $caption = get_string('create_new_question', 'jazzquiz');

--- a/classes/bank/jazzquiz_question_bank_view.php
+++ b/classes/bank/jazzquiz_question_bank_view.php
@@ -41,7 +41,7 @@ use \core_question\bank\search\category_condition as category_condition;
  * @copyright   2018 NTNU
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class jazzquiz_question_bank_view extends \core_question\bank\view {
+class jazzquiz_question_bank_view extends \core_question\local\bank\view {
 
     /**
      * Define the columns we want to be displayed on the question bank

--- a/classes/bank/question_bank_add_to_jazzquiz_action_column.php
+++ b/classes/bank/question_bank_add_to_jazzquiz_action_column.php
@@ -34,7 +34,7 @@ defined('MOODLE_INTERNAL') || die();
  * @copyright   2014 University of Wisconsin - Madison
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class question_bank_add_to_jazzquiz_action_column extends \core_question\bank\action_column_base {
+class question_bank_add_to_jazzquiz_action_column extends \core_question\local\bank\action_column_base {
 
     /**
      * Get the name of the column.

--- a/classes/bank/question_bank_add_to_jazzquiz_action_column.php
+++ b/classes/bank/question_bank_add_to_jazzquiz_action_column.php
@@ -61,7 +61,7 @@ class question_bank_add_to_jazzquiz_action_column extends \core_question\local\b
      * Get the required fields.
      * @return string[]
      */
-    public function get_required_fields() {
+    public function get_required_fields(): array {
         return ['q.id'];
     }
 

--- a/edit.php
+++ b/edit.php
@@ -174,7 +174,6 @@ function jazzquiz_edit() {
 
     // Process moving, deleting and unhiding questions...
     $questionbank = new \core_question\local\bank\view($contexts, $url, $COURSE, $cm);
-    $questionbank->process_actions();
 
     switch ($action) {
         case 'order':

--- a/edit.php
+++ b/edit.php
@@ -173,7 +173,7 @@ function jazzquiz_edit() {
     }
 
     // Process moving, deleting and unhiding questions...
-    $questionbank = new \core_question\bank\view($contexts, $url, $COURSE, $cm);
+    $questionbank = new \core_question\local\bank\view($contexts, $url, $COURSE, $cm);
     $questionbank->process_actions();
 
     switch ($action) {

--- a/edit.php
+++ b/edit.php
@@ -50,14 +50,14 @@ function jazzquiz_session_open($jazzquizid) {
 
 /**
  * Gets the question bank view based on the options passed in at the page setup.
- * @param \question_edit_contexts $contexts
+ * @param \core_question\local\bank\question_edit_contexts $contexts
  * @param jazzquiz $jazzquiz
  * @param \moodle_url $url
  * @param array $pagevars
  * @return string
  * @throws \coding_exception
  */
-function get_qbank_view(\question_edit_contexts $contexts, jazzquiz $jazzquiz, \moodle_url $url, array $pagevars) {
+function get_qbank_view(\core_question\local\bank\question_edit_contexts $contexts, jazzquiz $jazzquiz, \moodle_url $url, array $pagevars) {
     $qperpage = optional_param('qperpage', 10, PARAM_INT);
     $qpage = optional_param('qpage', 0, PARAM_INT);
     // Capture question bank display in buffer to have the renderer render output.
@@ -69,14 +69,14 @@ function get_qbank_view(\question_edit_contexts $contexts, jazzquiz $jazzquiz, \
 
 /**
  * Echos the list of questions using the renderer for jazzquiz.
- * @param \question_edit_contexts $contexts
+ * @param \core_question\local\bank\question_edit_contexts $contexts
  * @param jazzquiz $jazzquiz
  * @param \moodle_url $url
  * @param array $pagevars
  * @throws \coding_exception
  * @throws \moodle_exception
  */
-function list_questions(\question_edit_contexts $contexts, jazzquiz $jazzquiz, \moodle_url $url, array $pagevars) {
+function list_questions(\core_question\local\bank\question_edit_contexts $contexts, jazzquiz $jazzquiz, \moodle_url $url, array $pagevars) {
     $qbankview = get_qbank_view($contexts, $jazzquiz, $url, $pagevars);
     $jazzquiz->renderer->list_questions($jazzquiz, $jazzquiz->questions, $qbankview, $url);
 }
@@ -119,13 +119,13 @@ function jazzquiz_edit_edit_question(jazzquiz $jazzquiz) {
 
 /**
  * @param jazzquiz $jazzquiz
- * @param \question_edit_contexts $contexts
+ * @param \core_question\local\bank\question_edit_contexts $contexts
  * @param \moodle_url $url
  * @param $pagevars
  * @throws \coding_exception
  * @throws \moodle_exception
  */
-function jazzquiz_edit_qlist(jazzquiz $jazzquiz, \question_edit_contexts $contexts, \moodle_url $url, array $pagevars) {
+function jazzquiz_edit_qlist(jazzquiz $jazzquiz, \core_question\local\bank\question_edit_contexts $contexts, \moodle_url $url, array $pagevars) {
     $jazzquiz->renderer->header($jazzquiz, 'edit');
     list_questions($contexts, $jazzquiz, $url, $pagevars);
     $jazzquiz->renderer->footer();

--- a/edit.php
+++ b/edit.php
@@ -60,10 +60,18 @@ function jazzquiz_session_open($jazzquizid) {
 function get_qbank_view(\core_question\local\bank\question_edit_contexts $contexts, jazzquiz $jazzquiz, \moodle_url $url, array $pagevars) {
     $qperpage = optional_param('qperpage', 10, PARAM_INT);
     $qpage = optional_param('qpage', 0, PARAM_INT);
+    $new_pagevars = [
+        'qpage' => $qpage,
+        'qperpage' => $qperpage,
+        'cat' => $pagevars['cat'],
+        'recurse' => true,
+        'showhidden' => true,
+        'qbshowtext' => true
+    ];
     // Capture question bank display in buffer to have the renderer render output.
     ob_start();
     $questionbank = new bank\jazzquiz_question_bank_view($contexts, $url, $jazzquiz->course, $jazzquiz->cm);
-    $questionbank->display('editq', $qpage, $qperpage, $pagevars['cat'], true, true, true);
+    $questionbank->display($new_pagevars, 'editq');
     return ob_get_clean();
 }
 


### PR DESCRIPTION
The edit tab used to display errors and once those were fixed was completely blank due to more errors. These commits fix all of those bugs and bring the tab to feature parity with the plugin running on Moodle 3.11 and earlier.

Fixes #81 and #83