### PR TITLE
Added IdNumber idetentefier to report

### DIFF
--- a/classes/exporter.php
+++ b/classes/exporter.php
@@ -153,11 +153,19 @@ class exporter {
         $name = $session->data->id . '_' . $session->data->name;
         $attendances = $session->get_attendances();
         $this->csv_file("session_{$name}_attendance");
-        echo "Student\tResponses\r\n";
+        echo "IdNumber\tFirst Name\tLast Name\tResponses\r\n";
         foreach ($attendances as $attendance) {
-            $name = $attendance['name'];
+            $idnumber = $attendance['idnumber'];
+            $userFirstLastName = explode(', ', $attendance['name']);
+            if(sizeof($userFirstLastName)){
+                $lastName = $userFirstLastName[0];
+                $firstName = $userFirstLastName[1];
+            } else {
+                $lastName = $userFirstLastName[0];
+                $firstName = $userFirstLastName[0]; //for anonymous, but it doesn't even make sense since if it's anon, not name should display
+            }
             $count = $attendance['count'];
-            echo "$name\t$count\r\n";
+            echo "$idnumber\t$lastName\t$firstName\t$count\r\n";
         }
     }
 

--- a/classes/exporter.php
+++ b/classes/exporter.php
@@ -157,7 +157,7 @@ class exporter {
         foreach ($attendances as $attendance) {
             $idnumber = $attendance['idnumber'];
             $userFirstLastName = explode(', ', $attendance['name']);
-            if(count($userFirstLastName) >= 2){
+            if (count($userFirstLastName) >= 2) {
                 $lastName = $userFirstLastName[0];
                 $firstName = $userFirstLastName[1];
             } else {

--- a/classes/exporter.php
+++ b/classes/exporter.php
@@ -157,12 +157,12 @@ class exporter {
         foreach ($attendances as $attendance) {
             $idnumber = $attendance['idnumber'];
             $userFirstLastName = explode(', ', $attendance['name']);
-            if(sizeof($userFirstLastName)){
+            if(count($userFirstLastName) >= 2){
                 $lastName = $userFirstLastName[0];
                 $firstName = $userFirstLastName[1];
             } else {
                 $lastName = $userFirstLastName[0];
-                $firstName = $userFirstLastName[0]; //for anonymous, but it doesn't even make sense since if it's anon, not name should display
+                $firstName = $userFirstLastName[0]; //for anonymous, but it doesn't even make sense since if it's anon, no name should display
             }
             $count = $attendance['count'];
             echo "$idnumber\t$lastName\t$firstName\t$count\r\n";

--- a/classes/jazzquiz_session.php
+++ b/classes/jazzquiz_session.php
@@ -139,11 +139,12 @@ class jazzquiz_session {
         if (!$user) {
             return '?';
         }
-        return fullname($user);
+        $userFirstLastName = $user->lastname . ', ' . $user->firstname;
+        return $userFirstLastName;
     }
 
     public function user_name_for_attendance($userid) {
-        global $DB;
+        global $DB, $USER;
         if ($this->requires_anonymous_attendance() || is_null($userid)) {
             return get_string('anonymous', 'jazzquiz');
         }
@@ -151,7 +152,20 @@ class jazzquiz_session {
         if (!$user) {
             return '?';
         }
-        return fullname($user);
+        $userFirstLastName = $user->lastname . ', ' . $user->firstname;
+        return $userFirstLastName;
+    }
+
+    public function user_idNumber_for_attendance($userid) {
+        global $DB, $USER;
+        if ($this->requires_anonymous_attendance() || is_null($userid)) {
+            return get_string('anonymous', 'jazzquiz');
+        }
+        $user = $DB->get_record('user', ['id' => $userid]);
+        if (!$user) {
+            return '?';
+        }
+        return $user->idnumber;
     }
 
     /**
@@ -475,6 +489,7 @@ class jazzquiz_session {
         $records = $DB->get_records('jazzquiz_attendance', ['sessionid' => $this->data->id]);
         foreach ($records as $record) {
             $attendances[] = [
+                'idnumber' => $this->user_idNumber_for_attendance($record->userid),
                 'name' => $this->user_name_for_attendance($record->userid),
                 'count' => $record->numresponses
             ];

--- a/classes/jazzquiz_session.php
+++ b/classes/jazzquiz_session.php
@@ -144,7 +144,7 @@ class jazzquiz_session {
     }
 
     public function user_name_for_attendance($userid) {
-        global $DB, $USER;
+        global $DB;
         if ($this->requires_anonymous_attendance() || is_null($userid)) {
             return get_string('anonymous', 'jazzquiz');
         }
@@ -156,8 +156,8 @@ class jazzquiz_session {
         return $userFirstLastName;
     }
 
-    public function user_idNumber_for_attendance($userid) {
-        global $DB, $USER;
+    public function user_idnumber_for_attendance($userid) {
+        global $DB;
         if ($this->requires_anonymous_attendance() || is_null($userid)) {
             return get_string('anonymous', 'jazzquiz');
         }
@@ -489,7 +489,7 @@ class jazzquiz_session {
         $records = $DB->get_records('jazzquiz_attendance', ['sessionid' => $this->data->id]);
         foreach ($records as $record) {
             $attendances[] = [
-                'idnumber' => $this->user_idNumber_for_attendance($record->userid),
+                'idnumber' => $this->user_idnumber_for_attendance($record->userid),
                 'name' => $this->user_name_for_attendance($record->userid),
                 'count' => $record->numresponses
             ];

--- a/lang/en/jazzquiz.php
+++ b/lang/en/jazzquiz.php
@@ -162,6 +162,7 @@ $string['attendance'] = 'Attendance';
 $string['a_students_answered'] = '<b>{$a}</b> students answered at least one question.';
 $string['no_attempts_found'] = 'No attempts found.';
 $string['student'] = 'Student';
+// $string['student_id'] = 'StudentID'; //not working in report.mustache, not sure why
 $string['select_session'] = 'Select session to review:';
 $string['attendance_list'] = 'Attendance list';
 $string['download_report'] = 'Download report';

--- a/templates/report.mustache
+++ b/templates/report.mustache
@@ -46,11 +46,13 @@
             <h2>{{# str }} attendance_list, jazzquiz {{/str}}</h2>
             <table>
                 <tr>
+                    <th>Student ID</th> 
                     <th>{{# str }} student, jazzquiz {{/str}}</th>
                     <th>{{# str }} responses, jazzquiz {{/ str }}</th>
                 </tr>
                 {{# students }}
                     <tr>
+                        <td>{{ idnumber }}</td>
                         <td>{{ name }}</td>
                         <td>{{# str }} a_responses, jazzquiz, {{ count }} {{/ str }}</td>
                     </tr>


### PR DESCRIPTION
I've added the idnumber to the reports tab/csv file which is currently optional in moodle, but which a lot of universities use as a specific number to identify a student.

I've also split fullname (again, only in reports) to name and surname so people can sort people easier (usually by surname, but now they have the ability to also do it by firstname).