### PR TITLE
Suggestion: Change question save button label from 'save' to 'submit'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 ### Changed
-- 
+- Submission button for student answer changed from Save to Submit.
 
 ## [1.2.1] - 2023-06-26
 

--- a/templates/question.mustache
+++ b/templates/question.mustache
@@ -5,7 +5,7 @@
         {{^ instructor }}
         <div class="save_row">
             <div class="jazzquiz-save-question">
-                <button class="btn btn-primary">Save</button>
+                <button class="btn btn-primary">Submit</button>
             </div>
         </div>
         {{/ instructor }}


### PR DESCRIPTION
See discussion here: <a href="https://github.com/KQMATH/moodle-mod_jazzquiz/issues/117">#117</a>
<br/>
Suggested new layout to active quiz question:
<br/>
<img width="410" alt="Skjermbilde 2023-08-01 kl  10 33 25" src="https://github.com/jhoopes/moodle-mod_activequiz/assets/44703456/7cb7f80a-f900-4b11-a2d7-0b64372551e8">


Closes #117 